### PR TITLE
fix :: 세션 미들웨어 등록 순서 수정

### DIFF
--- a/src/middlewares/auth/authMiddleware.ts
+++ b/src/middlewares/auth/authMiddleware.ts
@@ -5,7 +5,7 @@ export const requireAuth = (
   res: express.Response,
   next: express.NextFunction
 ) => {
-  if (!req.session.user) {
+  if (!req.session || !req.session.user) {
     res.status(401).json({ message: "로그인이 필요합니다." });
     return;
   }
@@ -17,6 +17,10 @@ export const requireNoAuth = (
   res: express.Response,
   next: express.NextFunction
 ) => {
+  if (!req.session) {
+    res.status(500).json({ message: "세션이 초기화되지 않았습니다." });
+    return;
+  }
   if (req.session.user) {
     res.status(400).json({ message: "이미 로그인되어 있습니다." });
     return;
@@ -29,7 +33,7 @@ export const requireAdmin = (
   res: express.Response,
   next: express.NextFunction
 ) => {
-  if (!req.session.user) {
+  if (!req.session || !req.session.user) {
     res.status(401).json({ message: "로그인이 필요합니다." });
     return;
   }


### PR DESCRIPTION
## Summary
- Express 미들웨어 등록 순서 문제로 인한 세션 초기화 에러 수정
- 세션 미들웨어를 라우터보다 먼저 등록하도록 변경
- authMiddleware에서 req.session null 체크 추가
- Redis 중앙집중화 작업 중 발생한 회귀 버그 수정

## Problem
Redis 중앙집중화 작업 중 세션 미들웨어 설정을 `startServer()` 함수 내부로 이동하면서, 라우터보다 나중에 세션이 등록되는 문제 발생:
```
TypeError: Cannot read properties of undefined (reading 'user')
```

## Solution
1. 세션 미들웨어를 초기화 시점에 등록 (app.ts:320)
2. 라우터 등록 전에 세션이 설정되도록 순서 변경
3. authMiddleware에서 방어적 null 체크 추가

## Test plan
- [x] /auth/login 엔드포인트 정상 동작 확인
- [x] 세션 미들웨어가 모든 라우터에서 사용 가능한지 확인
- [x] Redis 연결 여부와 관계없이 세션 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session initialization to reduce missing-session errors during startup.
  * Authentication now consistently returns 401 when not logged in; admin checks aligned for clearer access control.
  * Routes handle absent sessions more predictably with clearer error responses.

* **Refactor**
  * Simplified session setup with an upgrade path to Redis when available, enhancing reliability without restarts.
  * Reordered middleware so session handling occurs before authentication for consistent user state across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->